### PR TITLE
feat(pull_request_template): add fields for author, name, and repository url

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,31 +1,49 @@
 # Plugin Submission Form
 
-## 1. Submission Type
+## 1. Metadata
+<!--
+Please provide the following metadata of your plugin to make it easier for the reviewer to check the changes.
+  - Plugin Author : The author of the plugin which is defined in your manifest.yaml
+  - Plugin Name   : The name of the plugin which is defined in your manifest.yaml
+  - Repository URL: The URL of the repository where the source code of your plugin is hosted
+-->
+
+- **Plugin Author**: 
+- **Plugin Name**: 
+- **Repository URL**: 
+
+## 2. Submission Type
+
 - [ ] New plugin submission
 - [ ] Version update for existing plugin
 
-## 2. Description
+## 3. Description
 <!-- Please briefly describe the purpose of the new plugin or the updates made to the existing plugin -->
 
-## 3. Checklist
+## 4. Checklist
+
 - [ ] I have read and followed the Publish to Dify Marketplace guidelines
 - [ ] I have read and comply with the Plugin Developer Agreement
 - [ ] I confirm my plugin works properly on both Dify Community Edition and Cloud Version
 - [ ] I confirm my plugin has been thoroughly tested for completeness and functionality
 - [ ] My plugin brings new value to Dify
 
-## 4. Documentation Checklist
+## 5. Documentation Checklist
+
 Please confirm that your plugin README includes all necessary information:
+
 - [ ] Step-by-step setup instructions
 - [ ] Detailed usage instructions
 - [ ] All required APIs and credentials are clearly listed
 - [ ] Connection requirements and configuration details
 
-## 5. Privacy Protection Information
+## 6. Privacy Protection Information
+
 Based on Dify Plugin Privacy Protection [Guidelines](https://docs.dify.ai/plugins/publish-plugins/publish-to-dify-marketplace/plugin-privacy-protection-guidelines):
 
 ### Data Collection
 <!-- Does your plugin collect any user personal data? If yes, please list what types of user personal data are being collected according to the Plugin Privacy Protection Guidelines (for example: Email address, IP address, Age, etc) -->
 
 ### Privacy Policy
+
 - [ ] I confirm that I have prepared and included a privacy policy in my plugin package based on the Plugin Privacy Protection Guidelines


### PR DESCRIPTION
## Changes

This PR adds following fields to `.github/pull_request_template.md`:

- Plugin Author
- Plugin Name
- Repository URL

The current `difypkg` file does not contain information that identifies the repository where its source code is hosted.

Even if, in the future, it becomes possible to keep the repository URL in the plugin's manifest, having a link in the PR description is more convenient than unzipping and checking the `difypkg`.

This change not only makes it easier to review but also provides users with a clue to identify the repository hosting the plugin.

Related to: #100