### PR TITLE
chore(ci): migrate runners to depot

### DIFF
--- a/.github/workflows/pre-check-plugin.yaml
+++ b/.github/workflows/pre-check-plugin.yaml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   pre-check-plugin:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   upload-merged-plugin:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Migrate GitHub-hosted workflow runners to Depot runners.

- Replace ubuntu-latest / ubuntu-22.04 with depot-ubuntu-24.04
- Use depot-ubuntu-24.04-4 for higher compute build jobs