### PR TITLE
ci: speed up pre-check-plugin workflow

### DIFF
--- a/.github/workflows/pre-check-plugin.yaml
+++ b/.github/workflows/pre-check-plugin.yaml
@@ -2,16 +2,21 @@ name: Pre Check Plugin
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, review_requested, edited]
-    branches: 
+    types: [opened, synchronize, ready_for_review]
+    branches:
       - main
       - dev
     paths-ignore:
       - ".github/**"
       - ".gitignore"
+      - "**/.gitignore"
       - "unpacked_plugin/**"
-      - "README.md"
+      - "**/*.md"
       - "LICENSE"
+
+concurrency:
+  group: pre-check-plugin-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 env:
   REPO_NAME: langgenius/dify-plugins
@@ -27,6 +32,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 2
 
       - name: Clone Marketplace Toolkit
         run: |
@@ -45,7 +51,6 @@ jobs:
       - name: Install Dependencies
         run: |
           echo "Installing Python dependencies..."
-          python -m pip install --upgrade pip
           pip install requests
           
           echo "Ensuring required build tools system dependencies are available..."
@@ -69,12 +74,12 @@ jobs:
 
       - name: Get PR Path
         run: |
-          echo "Retrieving PR files information..."
-          if ! PR_FILES=$(gh pr view -R ${{ env.REPO_NAME }} ${{ github.event.pull_request.number }} --json files --jq .files); then
-            echo "Failed to retrieve PR files. Make sure PR number and repository are correct."
+          echo "Retrieving PR files information from git diff..."
+          if ! PR_FILES=$(git diff --name-only HEAD^1 HEAD^2 | jq -R -s 'split("\n") | map(select(length > 0) | {path: .})'); then
+            echo "Failed to compute changed files from git diff."
             exit 1
           fi
-          
+
           export PR_FILES
           
           echo "Checking for plugin package file changes..."
@@ -288,23 +293,14 @@ jobs:
           
           echo "Running packaging check..."
           
-          # Check if plugin daemon exists and is executable
-          if [ ! -f ".scripts/dify-plugin-linux-amd64" ]; then
-            ERROR_MSG="Plugin daemon file not found"
+          # Check if plugin daemon exists (executable bit set at download time)
+          if [ ! -x ".scripts/dify-plugin-linux-amd64" ]; then
+            ERROR_MSG="Plugin daemon file not found or not executable"
             echo "$ERROR_MSG" >> $ERROR_FILE
             echo "$ERROR_MSG"
             exit 1
           fi
-          
-          if [ ! -x ".scripts/dify-plugin-linux-amd64" ]; then
-            chmod +x .scripts/dify-plugin-linux-amd64 || {
-              ERROR_MSG="Failed to make plugin daemon executable"
-              echo "$ERROR_MSG" >> $ERROR_FILE
-              echo "$ERROR_MSG"
-              exit 1
-            }
-          fi
-          
+
           # Run the packaging check with a timeout
           timeout 300 python3 .scripts/uploader/upload-package.py -d "$PLUGIN_PATH" -t "$MARKETPLACE_TOKEN" --plugin-daemon-path .scripts/dify-plugin-linux-amd64 -u "$MARKETPLACE_BASE_URL" -f --test || {
             ERROR_MSG="Packaging check failed or timed out"


### PR DESCRIPTION
## Summary
Six low-risk wins on `.github/workflows/pre-check-plugin.yaml` to cut PR feedback time and stop wasting compute on no-op re-runs.

- **Cancel superseded runs.** New `concurrency` group keyed on PR number cancels in-progress runs when a new commit is pushed. Today rapid-fire pushes pile up and each run drives to completion.
- **Trim noisy triggers.** Dropped `edited` and `review_requested` from `types`. They re-run the entire pipeline when no code changed (title edits, reviewer assignments).
- **Replace `gh pr view` with `git diff`.** The "Get PR Path" step now computes changed files locally from the merge commit (`HEAD^1`...`HEAD^2`) and emits the same `[{path: ...}]` shape that `.scripts/validator/check-pkg-paths.py` expects via `PR_FILES`. No upstream script change. `actions/checkout` now uses `fetch-depth: 2` so both parents are reachable.
- **Drop `pip install --upgrade pip`.** Unnecessary on a pinned 3.12.7 interpreter.
- **Remove duplicate `chmod +x` for the plugin daemon.** Already executable from the download step; the defensive re-`chmod` block in "Check Packaging" is dead weight.
- **Broaden `paths-ignore`.** Now skips `**/*.md` and `**/.gitignore` so doc-only commits don't trigger the workflow. Mixed PRs (`.difypkg` + markdown) still run because `paths-ignore` only skips when *all* paths match.

## Test plan
- [ ] Workflow YAML parses (validated locally with `yaml.safe_load`).
- [ ] On a real PR that touches a `.difypkg`, confirm "Get PR Path" prints the package path and the rest of the pipeline runs unchanged.
- [ ] On a docs-only PR (e.g., README edit), confirm the workflow does not trigger.
- [ ] Push two commits in quick succession; confirm the older run is cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)