### PR TITLE
ci: restore PR file lookup

### DIFF
--- a/.github/workflows/pre-check-plugin.yaml
+++ b/.github/workflows/pre-check-plugin.yaml
@@ -74,9 +74,9 @@ jobs:
 
       - name: Get PR Path
         run: |
-          echo "Retrieving PR files information from git diff..."
-          if ! PR_FILES=$(git diff --name-only HEAD^1 HEAD^2 | jq -R -s 'split("\n") | map(select(length > 0) | {path: .})'); then
-            echo "Failed to compute changed files from git diff."
+          echo "Retrieving PR files information..."
+          if ! PR_FILES=$(gh pr view -R ${{ env.REPO_NAME }} ${{ github.event.pull_request.number }} --json files --jq .files); then
+            echo "Failed to retrieve PR files. Make sure PR number and repository are correct."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Restore the pre-check workflow's Get PR Path step to read the pull request file list via GitHub API.
- Avoid comparing the synthetic pull_request merge commit parents, which can include unrelated base-branch changes for stale PR branches.

## Testing
- Ran check-pkg-paths.py with an API-shaped single .difypkg PR_FILES payload.