### PR TITLE
fix(ci): accept SDK 0.9.0+ hyphenated package name in pre-check version detection

### DIFF
--- a/.github/workflows/pre-check-plugin.yaml
+++ b/.github/workflows/pre-check-plugin.yaml
@@ -246,7 +246,11 @@ jobs:
               
               # Determine installation method based on dify_plugin version
               echo "Detecting dify_plugin version..."
-              dify_version=$(pip list | grep -o 'dify_plugin\s\+[0-9.]\+' | awk '{print $2}' || echo "not_found")
+              dify_version=$(pip list | grep -oE 'dify[-_]plugin[[:space:]]+[0-9][0-9.a-zA-Z]*' | awk '{print $2}')
+              if [ -z "$dify_version" ]; then
+                dify_version="not_found"
+              fi
+
               
               if [ "$dify_version" = "not_found" ]; then
                 echo "dify_plugin not found in installed packages, using default configuration"


### PR DESCRIPTION
## Summary

The `pre-check-plugin` workflow's `dify_plugin` version detection step misses SDK 0.9.0+, silently routing it to the unsupported `INSTALL_METHOD=aws_lambda` branch and failing the entire pre-check with an unrelated pydantic `ValidationError`. This patch fixes the detection without regressing SDK ≤ 0.7.4.

## Root cause

`.github/workflows/pre-check-plugin.yaml` detects the installed SDK with:

```bash
dify_version=$(pip list | grep -o 'dify_plugin\s\+[0-9.]\+' | awk '{print $2}' || echo "not_found")
```

Two latent bugs combine:

1. **Naming**: SDK ≤ 0.7.4 appears in `pip list` as `dify_plugin` (underscore), but **SDK 0.9.0 normalizes to `dify-plugin` (hyphen)**. The underscore-only regex matches nothing for 0.9.0+.
2. **Empty fall-through**: `grep -o | awk` exits 0 with empty output on a miss. The `|| echo "not_found"` never fires; `dify_version` becomes the empty string. The `if "$dify_version" = "not_found"` check is skipped, and `Version('') > Version('0.0.1b64')` raises `packaging.version.InvalidVersion`, sending the script to `INSTALL_METHOD=aws_lambda`. SDK 0.9.0's `DifyPluginEnv.INSTALL_METHOD` enum only accepts `local | remote | serverless`, so pydantic raises:

   ```
   ValidationError: 1 validation error for DifyPluginEnv
   INSTALL_METHOD
     Input should be 'local', 'remote' or 'serverless' [type=enum, input_value='aws_lambda', input_type=str]
   ```

## Fix

```diff
-              dify_version=$(pip list | grep -o 'dify_plugin\s\+[0-9.]\+' | awk '{print $2}' || echo "not_found")
+              dify_version=$(pip list | grep -oE 'dify[-_]plugin[[:space:]]+[0-9][0-9.a-zA-Z]*' | awk '{print $2}')
+              if [ -z "$dify_version" ]; then
+                dify_version="not_found"
+              fi
```

- Broaden the regex to `dify[-_]plugin` so both naming forms are accepted.
- Switch from `-o` to `-oE` so the alternation works as ERE.
- Explicitly fold the empty-output case into `not_found`.

## Verification

I extracted the workflow's bash block verbatim into a local script and ran it against two clean venvs (`python3.12 -m venv`), one with `dify_plugin==0.9.0` and one with `dify_plugin==0.7.4`, both before and after the patch:

| SDK in venv | `pip list` row | OLD script (current main) | NEW script (this PR) |
|---|---|---|---|
| 0.9.0 | `dify-plugin        0.9.0` (hyphen) | `Found dify_plugin version: ` → `Version('')` → `InvalidVersion` → **`aws_lambda`** | `Found dify_plugin version: 0.9.0` → **`serverless`** ✅ |
| 0.7.4 | `dify_plugin        0.7.4` (underscore) | `Found dify_plugin version: 0.7.4` → **`serverless`** ✅ | `Found dify_plugin version: 0.7.4` → **`serverless`** ✅ (no regression) |

The OLD-script + SDK 0.9.0 row matches exactly what is observed in [PR #2447 CI run 26268160995](https://github.com/langgenius/dify-plugins/actions/runs/26268160995/job/77994468503): `Found dify_plugin version: ` (empty) followed by `pydantic_core._pydantic_core.ValidationError`.

## Related

- Surfaced by PR #2447 (approved by @crazywoola, blocked by this CI bug). Details and reproduction logs are in [the comment](https://github.com/langgenius/dify-plugins/pull/2447#issuecomment-4551423763).
- Any SDK 0.9.0+ submission would otherwise fail pre-check; e.g. the latest PyPI release is 0.9.0 at time of writing.
