### PR TITLE
fix:  pre-check plugin install method detection

### DIFF
--- a/.github/workflows/pre-check-plugin.yaml
+++ b/.github/workflows/pre-check-plugin.yaml
@@ -244,22 +244,42 @@ jobs:
                 exit 1
               }
               
-              # Determine installation method based on dify_plugin version
+              # Determine installation method based on the installed dify_plugin distribution.
               echo "Detecting dify_plugin version..."
-              dify_version=$(pip list | grep -o 'dify_plugin\s\+[0-9.]\+' | awk '{print $2}' || echo "not_found")
-              
-              if [ "$dify_version" = "not_found" ]; then
-                echo "dify_plugin not found in installed packages, using default configuration"
-                export INSTALL_METHOD=aws_lambda
-                export AWS_LAMBDA_PORT=8080
-                export AWS_LAMBDA_HOST=0.0.0.0
+              dify_version=$(python3 - <<'PY' || true
+              from importlib.metadata import PackageNotFoundError, version
+              for dist_name in ("dify_plugin", "dify-plugin"):
+                  try:
+                      print(version(dist_name))
+                      break
+                  except PackageNotFoundError:
+                      continue
+              else:
+                  raise SystemExit(1)
+              PY
+              )
+              if [ -z "$dify_version" ]; then
+                echo "dify_plugin not found in installed packages, using serverless installation method"
+                export INSTALL_METHOD=serverless
+                export SERVERLESS_PORT=8080
+                export SERVERLESS_HOST=0.0.0.0
               else
                 target_version="0.0.1b64"
                 echo "Found dify_plugin version: $dify_version"
                 echo "Comparing with target version: $target_version"
                 
                 # Set environment variables based on version comparison
-                if python -c "from packaging.version import Version; exit(0 if Version('$dify_version') > Version('$target_version') else 1)"; then
+                if DIFY_PLUGIN_VERSION="$dify_version" TARGET_VERSION="$target_version" python3 - <<'PY'
+              import os
+              from packaging.version import InvalidVersion, Version
+              try:
+                  use_serverless = Version(os.environ["DIFY_PLUGIN_VERSION"]) >= Version(os.environ["TARGET_VERSION"])
+              except InvalidVersion as exc:
+                  print(f"Unable to parse dify_plugin version, using serverless installation method: {exc}")
+                  use_serverless = True
+              raise SystemExit(0 if use_serverless else 1)
+              PY
+                then
                     echo "Using serverless installation method"
                     export INSTALL_METHOD=serverless
                     export SERVERLESS_PORT=8080


### PR DESCRIPTION
## Summary

Fix the `pre-check-plugin` workflow's `Check Plugin Install` step so it detects the installed `dify_plugin` runtime version using Python package metadata instead of parsing `pip list` output.

## Root Cause

The previous `pip list | grep` version detection could return an empty string for installed `dify_plugin` packages. That empty version caused `packaging.version.InvalidVersion`, which dropped the workflow into the legacy `aws_lambda` install method path. Current `dify_plugin` runtimes validate `INSTALL_METHOD` and only accept `local`, `remote`, or `serverless`, so the install test failed before exercising the submitted plugin.

## Changes

- Use `importlib.metadata.version(...)` to detect the installed `dify_plugin` / `dify-plugin` distribution version.
- Default missing or unparseable runtime metadata to `INSTALL_METHOD=serverless`.
- Use `serverless` for runtimes at or above `0.0.1b64`, while preserving the legacy `aws_lambda` path for older pre-threshold runtimes.
- Use `python3` consistently in the workflow block.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/pre-check-plugin.yaml")'`
- `bash -n` on the extracted workflow shell block
- `git diff --check HEAD~1 HEAD`
- Simulated missing `dify_plugin` metadata selects `INSTALL_METHOD=serverless`
- Simulated `dify-plugin` `0.5.0` metadata selects `INSTALL_METHOD=serverless`