### PR TITLE
chore: Add plugin submission standards

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 - **Plugin name**:
 - **Version**:
 - **Source repository**:
-- **Package path**:
+- **Contact**:
 
 ## Submission type
 
@@ -16,6 +16,14 @@
 ## What changed
 
 <!-- Briefly describe what the plugin does or what changed in this version. -->
+
+## Risk level
+
+- [ ] Low risk
+- [ ] Medium risk
+- [ ] High risk
+
+<!-- Select one based on the risk classification in docs/plugin-submission-requirements.md. -->
 
 ## Required checks
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,50 +1,46 @@
-# Plugin Submission Form
+# Plugin Submission
 
-## 1. Metadata
+## Plugin information
+
+- **Author**:
+- **Plugin name**:
+- **Version**:
+- **Source repository**:
+- **Package path**:
+
+## Submission type
+
+- [ ] New plugin
+- [ ] Version update
+
+## What changed
+
+<!-- Briefly describe what the plugin does or what changed in this version. -->
+
+## Required checks
+
+- [ ] I have read and followed the [Marketplace submission requirements](docs/plugin-submission-requirements.md).
+- [ ] I have read and comply with the Plugin Developer Agreement.
+- [ ] I tested this plugin on Dify Community Edition and Dify Cloud, or documented any limitation below.
+- [ ] The package contains only files needed at runtime.
+- [ ] The package does not contain secrets, local credentials, `.env` files, `.git` directories, virtual environments, caches, logs, or IDE files.
+- [ ] The package does not contain executables or bundled binaries, or I explained why they are required below.
+- [ ] The plugin README includes setup steps, usage instructions, required APIs or credentials, connection requirements, and the source repository link.
+- [ ] The plugin includes `PRIVACY.md` or a hosted privacy policy, and `manifest.yaml` references it.
+- [ ] All user-facing text is primarily in English.
+
+## Security and privacy notes
+
 <!--
-Please provide the following metadata of your plugin to make it easier for the reviewer to check the changes.
-  - Plugin Author : The author of the plugin which is defined in your manifest.yaml
-  - Plugin Name   : The name of the plugin which is defined in your manifest.yaml
-  - Repository URL: The URL of the repository where the source code of your plugin is hosted
+List any sensitive capability, such as command execution, code execution, SQL, SSH/SFTP,
+browser automation, file operations, arbitrary URL fetching, proxying, or handling health,
+financial, biometric, children, or other sensitive data. Write "None" if not applicable.
 -->
 
-- **Plugin Author**: 
-- **Plugin Name**: 
-- **Repository URL**: 
+## Local validation
 
-## 2. Submission Type
+<!-- Paste the commands you ran and the result. -->
 
-- [ ] New plugin submission
-- [ ] Version update for existing plugin
+## Reviewer notes
 
-## 3. Description
-<!-- Please briefly describe the purpose of the new plugin or the updates made to the existing plugin -->
-
-## 4. Checklist
-
-- [ ] I have read and followed the Publish to Dify Marketplace guidelines
-- [ ] I have read and comply with the Plugin Developer Agreement
-- [ ] I confirm my plugin works properly on both Dify Community Edition and Cloud Version
-- [ ] I confirm my plugin has been thoroughly tested for completeness and functionality
-- [ ] My plugin brings new value to Dify
-
-## 5. Documentation Checklist
-
-Please confirm that your plugin README includes all necessary information:
-
-- [ ] Step-by-step setup instructions
-- [ ] Detailed usage instructions
-- [ ] All required APIs and credentials are clearly listed
-- [ ] Connection requirements and configuration details
-- [ ] Link to the repository for the plugin source code
-
-## 6. Privacy Protection Information
-
-Based on Dify Plugin Privacy Protection [Guidelines](https://docs.dify.ai/plugins/publish-plugins/publish-to-dify-marketplace/plugin-privacy-protection-guidelines):
-
-### Data Collection
-<!-- Does your plugin collect any user personal data? If yes, please list what types of user personal data are being collected according to the Plugin Privacy Protection Guidelines (for example: Email address, IP address, Age, etc) -->
-
-### Privacy Policy
-
-- [ ] I confirm that I have prepared and included a privacy policy in my plugin package based on the Plugin Privacy Protection Guidelines
+<!-- Optional: migration notes, known limitations, binary/package exceptions, or breaking changes. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,7 +35,7 @@
 - [ ] The package does not contain executables or bundled binaries, or I explained why they are required below.
 - [ ] The plugin README includes setup steps, usage instructions, required APIs or credentials, connection requirements, and the source repository link.
 - [ ] The plugin includes `PRIVACY.md` or a hosted privacy policy, and `manifest.yaml` references it.
-- [ ] All user-facing text is primarily in English.
+- [ ] All user-facing text is primarily in English, with any localized README files following the [i18n guidance](https://docs.dify.ai/en/develop-plugin/features-and-specs/plugin-types/multilingual-readme).
 
 ## Security and privacy notes
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 <p align="center">
     <a href="https://dify.ai" target="_blank">
         <img alt="Static Badge" src="https://img.shields.io/badge/Product-F04438"></a>
-    <a href="https://dify.ai/pricing" target="_blank">
-        <img alt="Static Badge" src="https://img.shields.io/badge/free-pricing?logo=free&color=%20%23155EEF&label=pricing&labelColor=%20%23528bff"></a>
+    <a href="https://cloud.dify.ai" target="_blank">
+        <img alt="Dify Cloud" src="https://img.shields.io/badge/Dify-Cloud?logo=cloud&color=%20%23155EEF&label=Cloud&labelColor=%20%23528bff"></a>
     <a href="https://discord.gg/FngNHpbcY7" target="_blank">
         <img src="https://img.shields.io/discord/1082486657678311454?logo=discord&labelColor=%20%235462eb&logoColor=%20%23f5f5f5&color=%20%235462eb"
             alt="chat on Discord"></a>
@@ -46,11 +46,11 @@
 
 ##### Models
 
-These plugins integrate various AI models (including mainstream LLM providers and custom model) to handle configuration and requests for LLM APIs. For more on creating a model plugin, take refer to [Quick Start: Model Plugin](https://docs.dify.ai/en/develop-plugin/dev-guides-and-walkthroughs/creating-new-model-provider).
+These plugins integrate various AI models, including mainstream LLM providers and custom models, to handle configuration and requests for model APIs. For more on creating a model plugin, refer to the [Dify Plugin documentation](https://docs.dify.ai/en/develop-plugin/getting-started/getting-started-dify-plugin).
 
 ##### Tools
 
-Tools refer to third-party services that can be invoked by Chatflow, Workflow, or Agent-type applications. They provide a complete API implementation to enhance the capabilities of Dify applications. For example, developing a Google Search plugin, please refer to [Quick Start: Tool Plugin](https://docs.dify.ai/en/develop-plugin/dev-guides-and-walkthroughs/tool-plugin).
+Tools are third-party services that can be invoked by Chatflow, Workflow, or Agent applications. They provide API-backed capabilities for Dify applications. For plugin type guidance, refer to [Choose a Plugin Type](https://docs.dify.ai/en/develop-plugin/getting-started/choose-plugin-type).
 
 ##### Agent Strategies
 
@@ -75,33 +75,33 @@ Check the [Plugins documentation](https://docs.dify.ai/en/develop-plugin/getting
 To publish your plugin on the Dify Marketplace, follow these steps:
 
 #### Development
-1. Develop and test your plugin according to the [Plugin Developer Guidelines](https://docs.dify.ai/en/develop-plugin/publishing/standards/contributor-covenant-code-of-conduct).
+1. Develop and test your plugin according to the [Plugin Development Guidelines](https://docs.dify.ai/en/develop-plugin/publishing/standards/contributor-covenant-code-of-conduct) and this repository's [Plugin Submission Requirements](docs/plugin-submission-requirements.md).
 
-2. Write a [Plugin Privacy Policy](https://docs.dify.ai/en/develop-plugin/publishing/standards/privacy-protection-guidelines) for your plugin in line with Dify’s privacy policy requirements. In your plugin’s [Manifest](https://docs.dify.ai/en/develop-plugin/features-and-specs/plugin-types/plugin-info-by-manifest) file, include the file path or URL for this privacy policy.
+2. Write a [Plugin Privacy Policy](https://docs.dify.ai/en/develop-plugin/publishing/standards/privacy-protection-guidelines) for your plugin in line with Dify's privacy requirements. In your plugin's manifest, include the file path or URL for this privacy policy.
 
-3. Leave your contact infomation and repository URL in `README.md`.
+3. Include your contact information and source repository URL in the plugin `README.md`.
 
 #### Publishing
 
 1. Package your plugin into `.difypkg` file for distribution.
 
-2. [Fork the this repository](https://github.com/langgenius/dify-plugins/fork).
+2. [Fork this repository](https://github.com/langgenius/dify-plugins/fork).
 
-3. Create an organization directory under the repository’s main structure, then create a subdirectory named after your plugin. Place your plugin’s source code and the packaged `.difypkg` file in that subdirectory (eg. `langgenius/dify-plugin/dify-plugin-0.0.1.difypkg`). You can place different versions in the same subdirectory. 
+3. Create an organization directory under the repository's main structure, then create a subdirectory named after your plugin. Place your plugin source code and the packaged `.difypkg` file in that subdirectory, for example `langgenius/dify-plugin/dify-plugin-0.0.1.difypkg`. You can place different versions in the same subdirectory.
 
-4. [Submit a Pull Request (PR)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) following the required PR template format, then wait for the review;
+4. [Submit a Pull Request (PR)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) following the required PR template format, then wait for review.
 
 5. Once approved, your plugin code will merge into the main branch, and the plugin will be automatically listed on the [Dify Marketplace](https://marketplace.dify.ai/).
 
 #### Updating/Bump
 
-1. When updating your plugin, ensure you increment the version in your plugin's `manifest.yaml` file.
+1. When updating your plugin, increment the version in your plugin's `manifest.yaml` file.
 
 2. Each PR for plugin updates must contain only one file change - the new `.difypkg` file. Check that the version hasn't been published before.
 
 3. If your update includes breaking changes, document them clearly in your plugin's README.md to prevent user issues.
 
-4. For faster plugin updates, you can set up automated PR workflows using the [GitHub Actions workflow template](https://docs.dify.ai/en/develop-plugin/publishing/marketplace-listing/plugin-auto-publish-pr). This will automate the PR creation process when you release new versions.
+4. For faster plugin updates, you can set up automated PR workflows using the [Plugin Auto-PR guide](https://docs.dify.ai/en/develop-plugin/publishing/marketplace-listing/plugin-auto-publish-pr). This automates packaging and PR creation when you release new versions.
 
 ### Security disclosure
 

--- a/docs/plugin-review-guidelines.md
+++ b/docs/plugin-review-guidelines.md
@@ -1,0 +1,29 @@
+# Plugin Review Guidelines
+
+Use this checklist when reviewing a plugin package before merge. It is intentionally lightweight and focused on issues that are hard to fix after publication.
+
+## Quick package inspection
+
+Unpack the submitted `.difypkg` and check the file list before reading the code. Reject or request changes if the package includes secrets, `.env`, `.git`, virtual environments, caches, logs, local settings, IDE files, OS-generated files, or unexplained executables.
+
+Confirm that the package has the expected runtime files, including `manifest.yaml`, README, privacy policy, provider or model definitions, tool/model/endpoint files, assets, and dependency files.
+
+## Documentation review
+
+Check that the README tells users how to configure and use the plugin, lists required credentials or APIs, explains connection requirements, and links to the source repository.
+
+Check that the privacy policy matches the plugin behavior and the third-party services it calls. If the plugin handles sensitive data, the policy should name the data types and explain where the data goes.
+
+## Security review
+
+Look for high-risk capabilities first: command execution, code execution, SQL, SSH/SFTP, file operations, browser automation, arbitrary URL fetching, proxying, and webhook forwarding.
+
+For high-risk plugins, verify that user inputs are constrained, network requests have timeouts, credentials are not returned in errors, and dangerous behavior is documented in the PR.
+
+## Dependency review
+
+Check `requirements.txt` or equivalent dependency files for unnecessary packages, direct URL installs, git-based installs, and very broad dependency ranges. Ask for justification when the dependency footprint is larger than the plugin behavior requires.
+
+## Merge expectation
+
+Only approve when the package content, documentation, privacy declaration, dependencies, and sensitive-capability disclosure are consistent with the plugin behavior.

--- a/docs/plugin-review-guidelines.md
+++ b/docs/plugin-review-guidelines.md
@@ -16,6 +16,8 @@ Check that the privacy policy matches the plugin behavior and the third-party se
 
 ## Security review
 
+Confirm that the PR risk level matches the plugin behavior. When a plugin fits multiple levels, review it at the higher level.
+
 Look for high-risk capabilities first: command execution, code execution, SQL, SSH/SFTP, file operations, browser automation, arbitrary URL fetching, proxying, and webhook forwarding.
 
 For high-risk plugins, verify that user inputs are constrained, network requests have timeouts, credentials are not returned in errors, and dangerous behavior is documented in the PR.

--- a/docs/plugin-submission-requirements.md
+++ b/docs/plugin-submission-requirements.md
@@ -26,6 +26,16 @@ Every submission must include:
 
 Keep dependencies minimal and explain unusual runtime requirements. Python plugins should avoid unbounded or unnecessary dependencies, direct URL installs, and git-based package installs unless the PR explains why they are required.
 
+## Risk classification
+
+Select one risk level in the PR template:
+
+- Low risk: The plugin only calls fixed, documented third-party HTTPS APIs and does not execute user-controlled code, commands, SQL, file operations, browser automation, or arbitrary network requests.
+- Medium risk: The plugin processes uploaded files or user-provided URLs, performs write actions in a third-party service, sends user content to external services, or handles personal data that is not highly sensitive.
+- High risk: The plugin can execute commands or code, run SQL, access databases, use SSH/SFTP, operate on filesystems, automate browsers, proxy or crawl arbitrary URLs, bundle executables, or handle health, financial, biometric, children, authentication, location, or other sensitive personal data.
+
+When more than one level seems possible, choose the higher risk level.
+
 ## Version updates
 
 Version update PRs should normally add only the new `.difypkg` file. The plugin version in `manifest.yaml` must be incremented and must not already exist on the Dify Marketplace.

--- a/docs/plugin-submission-requirements.md
+++ b/docs/plugin-submission-requirements.md
@@ -20,7 +20,7 @@ Every submission must include:
 - A valid `manifest.yaml` with accurate author, name, version, plugin type, runner, icon, and privacy fields.
 - A README with setup steps, usage instructions, required APIs or credentials, connection requirements, and a link to the source repository.
 - A `PRIVACY.md` file or hosted privacy policy that explains what user data is collected, stored, logged, or sent to third parties. If no user data is collected, say so explicitly.
-- Primary user-facing text in English. Additional translations are welcome.
+- Primary user-facing text in English. Additional localized README files are welcome and should follow the [i18n guidance](https://docs.dify.ai/en/develop-plugin/features-and-specs/plugin-types/multilingual-readme).
 
 ## Dependencies
 

--- a/docs/plugin-submission-requirements.md
+++ b/docs/plugin-submission-requirements.md
@@ -1,0 +1,44 @@
+# Plugin Submission Requirements
+
+These requirements keep Marketplace submissions reviewable and safe. They apply to every new plugin and version update submitted to this repository.
+
+## Package contents
+
+A `.difypkg` must contain only files required for the plugin to run in Dify.
+
+Do not include:
+
+- Secrets or local credentials, including `.env` files, access tokens, API keys, private keys, certificates with private material, or cloud credentials.
+- Development state, including `.git/`, virtual environments, dependency caches, build caches, test caches, `__pycache__/`, `.ruff_cache/`, logs, local settings, or IDE files.
+- OS-generated files, including `.DS_Store` and thumbnail databases.
+- Executables or bundled binaries, unless they are essential to the plugin and clearly explained in the PR.
+
+## Metadata and documentation
+
+Every submission must include:
+
+- A valid `manifest.yaml` with accurate author, name, version, plugin type, runner, icon, and privacy fields.
+- A README with setup steps, usage instructions, required APIs or credentials, connection requirements, and a link to the source repository.
+- A `PRIVACY.md` file or hosted privacy policy that explains what user data is collected, stored, logged, or sent to third parties. If no user data is collected, say so explicitly.
+- Primary user-facing text in English. Additional translations are welcome.
+
+## Dependencies
+
+Keep dependencies minimal and explain unusual runtime requirements. Python plugins should avoid unbounded or unnecessary dependencies, direct URL installs, and git-based package installs unless the PR explains why they are required.
+
+## Version updates
+
+Version update PRs should normally add only the new `.difypkg` file. The plugin version in `manifest.yaml` must be incremented and must not already exist on the Dify Marketplace.
+
+If the update has breaking changes, document them in the plugin README and summarize them in the PR.
+
+## Sensitive capabilities
+
+Plugins with sensitive capabilities receive extra review. Disclose these capabilities in the PR template:
+
+- Command execution, code execution, shell access, or sandbox control.
+- SQL execution, database write access, SSH, SFTP, filesystem operations, or browser automation.
+- Arbitrary URL fetching, proxying, crawling, webhook forwarding, or user-controlled network destinations.
+- Processing health, financial, biometric, children, location, authentication, or other sensitive personal data.
+
+Sensitive plugins should constrain user input, set request timeouts, avoid leaking credentials in errors or logs, and document the security boundary clearly.


### PR DESCRIPTION
## What changed

- Tightened the plugin PR template so submissions disclose package path, source repository, local validation, privacy status, package hygiene, binaries, and sensitive capabilities.
- Added lightweight Marketplace submission requirements under `docs/`.
- Added reviewer guidelines focused on package contents, documentation, privacy, dependencies, and high-risk capabilities.
- Refreshed README publishing guidance and fixed outdated or unclear links/descriptions.

## Why

This gives contributors and reviewers a small, concrete quality gate without adding GitHub CI or changing plugin runtime behavior.

## Validation

- Verified the updated Dify documentation links used by README return HTTP 200.
- Verified local relative links from README and the PR template resolve to existing repository files.
- Confirmed the staged diff only includes README, the PR template, and the new docs files.
