### PR TITLE
Add PR risk labeling workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,7 +27,7 @@
 
 ## Required checks
 
-- [ ] I have read and followed the [Marketplace submission requirements](docs/plugin-submission-requirements.md).
+- [ ] I have read and followed the [Marketplace submission requirements](https://github.com/langgenius/dify-plugins/blob/main/docs/plugin-submission-requirements.md).
 - [ ] I have read and comply with the Plugin Developer Agreement.
 - [ ] I tested this plugin on Dify Community Edition and Dify Cloud, or documented any limitation below.
 - [ ] The package contains only files needed at runtime.

--- a/.github/workflows/pr-risk-label.yaml
+++ b/.github/workflows/pr-risk-label.yaml
@@ -43,8 +43,7 @@ jobs:
             };
 
             const marker = '<!-- dify-plugins-risk-label-bot -->';
-            const warningBody = `${marker}
-            Please select exactly one risk level in the PR template: Low risk, Medium risk, or High risk. This helps Marketplace reviewers route the submission correctly.`;
+            const warningBody = `${marker}\nPlease select exactly one risk level in the PR template: Low risk, Medium risk, or High risk. This helps Marketplace reviewers route the submission correctly.`;
 
             const { owner, repo } = context.repo;
             const pr = context.payload.pull_request;

--- a/.github/workflows/pr-risk-label.yaml
+++ b/.github/workflows/pr-risk-label.yaml
@@ -2,7 +2,7 @@ name: PR Risk Label
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened, synchronize, ready_for_review]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   pull-requests: read

--- a/.github/workflows/pr-risk-label.yaml
+++ b/.github/workflows/pr-risk-label.yaml
@@ -67,8 +67,13 @@ jobs:
 
             for (const label of Object.values(riskLabels)) {
               try {
-                await github.rest.issues.getLabel({ owner, repo, name: label.name });
-                await updateLabel(label);
+                const { data: existing } = await github.rest.issues.getLabel({ owner, repo, name: label.name });
+                if (
+                  existing.color?.toUpperCase() !== label.color ||
+                  (existing.description ?? '') !== (label.description ?? '')
+                ) {
+                  await updateLabel(label);
+                }
               } catch (error) {
                 if (error.status !== 404) {
                   throw error;

--- a/.github/workflows/pr-risk-label.yaml
+++ b/.github/workflows/pr-risk-label.yaml
@@ -1,0 +1,151 @@
+name: PR Risk Label
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  pull-requests: read
+  issues: write
+
+jobs:
+  apply-risk-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply risk label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const riskLabels = {
+              low: {
+                name: 'risk: low',
+                color: '0E8A16',
+                description: 'Low-risk Marketplace submission',
+                pattern: /^- \[[xX]\] Low risk\s*$/m,
+              },
+              medium: {
+                name: 'risk: medium',
+                color: 'FBCA04',
+                description: 'Medium-risk Marketplace submission',
+                pattern: /^- \[[xX]\] Medium risk\s*$/m,
+              },
+              high: {
+                name: 'risk: high',
+                color: 'D93F0B',
+                description: 'High-risk Marketplace submission',
+                pattern: /^- \[[xX]\] High risk\s*$/m,
+              },
+              missing: {
+                name: 'risk: missing',
+                color: 'BFDADC',
+                description: 'Missing or invalid Marketplace risk selection',
+              },
+            };
+
+            const marker = '<!-- dify-plugins-risk-label-bot -->';
+            const warningBody = `${marker}
+            Please select exactly one risk level in the PR template: Low risk, Medium risk, or High risk. This helps Marketplace reviewers route the submission correctly.`;
+
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const issue_number = pr.number;
+            const body = pr.body || '';
+            const selected = Object.entries(riskLabels)
+              .filter(([key, config]) => key !== 'missing' && config.pattern.test(body))
+              .map(([, config]) => config.name);
+            const targetLabel = selected.length === 1 ? selected[0] : riskLabels.missing.name;
+            const allRiskLabelNames = Object.values(riskLabels).map((label) => label.name);
+
+            async function updateLabel(label) {
+              await github.rest.issues.updateLabel({
+                owner,
+                repo,
+                name: label.name,
+                color: label.color,
+                description: label.description,
+              });
+            }
+
+            for (const label of Object.values(riskLabels)) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label.name });
+                await updateLabel(label);
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+                try {
+                  await github.rest.issues.createLabel({
+                    owner,
+                    repo,
+                    name: label.name,
+                    color: label.color,
+                    description: label.description,
+                  });
+                } catch (createError) {
+                  if (createError.status !== 422) {
+                    throw createError;
+                  }
+                  await updateLabel(label);
+                }
+              }
+            }
+
+            for (const label of allRiskLabelNames.filter((name) => name !== targetLabel)) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label });
+              } catch (error) {
+                if (error.status !== 404) {
+                  throw error;
+                }
+              }
+            }
+
+            await github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number,
+              labels: [targetLabel],
+            });
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const managedComments = comments.filter(
+              (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker)
+            );
+
+            if (selected.length === 1) {
+              for (const comment of managedComments) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: comment.id,
+                });
+              }
+            } else if (managedComments.length > 0) {
+              const [firstComment, ...duplicateComments] = managedComments;
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: firstComment.id,
+                body: warningBody,
+              });
+              for (const comment of duplicateComments) {
+                await github.rest.issues.deleteComment({
+                  owner,
+                  repo,
+                  comment_id: comment.id,
+                });
+              }
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: warningBody,
+              });
+            }

--- a/.github/workflows/pr-risk-label.yaml
+++ b/.github/workflows/pr-risk-label.yaml
@@ -119,7 +119,7 @@ jobs:
               per_page: 100,
             });
             const managedComments = comments.filter(
-              (comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker)
+              (comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker)
             );
 
             if (selected.length === 1) {


### PR DESCRIPTION
## Summary

- Fix the Marketplace submission requirements link in the PR template by using the canonical GitHub URL.
- Add a lightweight `pull_request_target` workflow that labels PRs based on the risk checkbox selected in the PR body.
- Add/update one managed bot comment when the PR has no risk level or multiple risk levels selected.

## Risk level

- [x] Low risk
- [ ] Medium risk
- [ ] High risk

## Validation

- Parser sample cases passed: none, low, medium, high, multiple.
- Ruby YAML parse passed for `.github/workflows/pr-risk-label.yaml`.
- Embedded `github-script` JavaScript compile check passed.
- `git diff --check` passed.

## Notes

This workflow does not check out or execute PR code. It only reads the PR body and uses the GitHub API to manage labels and the workflow-owned bot comment.