### PR TITLE
ci: expand plugin validation with toolkit checks and run the uploader as a package

### DIFF
--- a/.github/workflows/pre-check-plugin-sandbox.yaml
+++ b/.github/workflows/pre-check-plugin-sandbox.yaml
@@ -1,11 +1,10 @@
-name: Pre Check Plugin
+name: Pre Check Plugin Sandbox
 
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review]
     branches:
-      - main
-      - dev
+      - precheck-sandbox
     paths-ignore:
       - ".github/**"
       - ".gitignore"
@@ -15,7 +14,7 @@ on:
       - "LICENSE"
 
 concurrency:
-  group: pre-check-plugin-${{ github.event.pull_request.number }}
+  group: pre-check-plugin-sandbox-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 env:
@@ -25,7 +24,7 @@ env:
   GH_TOKEN: ${{ github.token }}
 
 jobs:
-  pre-check-plugin:
+  pre-check-plugin-sandbox:
     runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout

--- a/.github/workflows/pre-check-plugin-sandbox.yaml
+++ b/.github/workflows/pre-check-plugin-sandbox.yaml
@@ -395,7 +395,7 @@ jobs:
           fi
 
           # Run the packaging check with a timeout
-          timeout 300 python3 .scripts/uploader/upload-package.py -d "$PLUGIN_PATH" -t "$MARKETPLACE_TOKEN" --plugin-daemon-path .scripts/dify-plugin-linux-amd64 -u "$MARKETPLACE_BASE_URL" -f --test || {
+          timeout 300 python3 .scripts/uploader -d "$PLUGIN_PATH" -t "$MARKETPLACE_TOKEN" --plugin-daemon-path .scripts/dify-plugin-linux-amd64 -u "$MARKETPLACE_BASE_URL" -f --test || {
             ERROR_MSG="Packaging check failed or timed out"
             echo "$ERROR_MSG" >> $ERROR_FILE
             echo "$ERROR_MSG"

--- a/.github/workflows/pre-check-plugin.yaml
+++ b/.github/workflows/pre-check-plugin.yaml
@@ -396,7 +396,7 @@ jobs:
           fi
 
           # Run the packaging check with a timeout
-          timeout 300 python3 .scripts/uploader/upload-package.py -d "$PLUGIN_PATH" -t "$MARKETPLACE_TOKEN" --plugin-daemon-path .scripts/dify-plugin-linux-amd64 -u "$MARKETPLACE_BASE_URL" -f --test || {
+          timeout 300 python3 .scripts/uploader -d "$PLUGIN_PATH" -t "$MARKETPLACE_TOKEN" --plugin-daemon-path .scripts/dify-plugin-linux-amd64 -u "$MARKETPLACE_BASE_URL" -f --test || {
             ERROR_MSG="Packaging check failed or timed out"
             echo "$ERROR_MSG" >> $ERROR_FILE
             echo "$ERROR_MSG"

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -116,4 +116,4 @@ jobs:
 
       - name: Upload Plugin
         run: |
-          python3 .scripts/uploader/upload-package.py -p ${{ env.PLUGIN_PATH }} -t ${{ secrets.MARKETPLACE_TOKEN }} --plugin-daemon-path .scripts/dify-plugin-linux-amd64 -u ${{ secrets.MARKETPLACE_BASE_URL }}
+          python3 .scripts/uploader -p ${{ env.PLUGIN_PATH }} -t ${{ secrets.MARKETPLACE_TOKEN }} --plugin-daemon-path .scripts/dify-plugin-linux-amd64 -u ${{ secrets.MARKETPLACE_BASE_URL }}

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -67,6 +67,53 @@ jobs:
             exit 1
           fi
 
+      - name: yq - portable yaml processor
+        uses: mikefarah/yq@v4.44.5
+        with:
+          cmd: yq --version
+
+      - name: Unpack Plugin for Final Validation
+        run: |
+          mkdir -p unpacked_plugin
+          unzip "$PLUGIN_PATH" -d unpacked_plugin
+
+      - name: Final Package Validation
+        run: |
+          python3 .scripts/validator/check-package-contents.py \
+            -d unpacked_plugin \
+            --package-file "$PLUGIN_PATH" \
+            --error-file /tmp/package_contents_errors.txt \
+            --warning-file /tmp/package_contents_warnings.txt
+
+          python3 .scripts/validator/check-package-secrets.py \
+            -d unpacked_plugin \
+            --error-file /tmp/package_secrets_errors.txt \
+            --warning-file /tmp/package_secrets_warnings.txt
+
+          python3 .scripts/validator/check-package-binaries.py \
+            -d unpacked_plugin \
+            --error-file /tmp/package_binaries_errors.txt \
+            --warning-file /tmp/package_binaries_warnings.txt
+
+          python3 .scripts/validator/check-manifest-metadata.py \
+            -d unpacked_plugin \
+            --error-file /tmp/manifest_errors.txt \
+            --warning-file /tmp/manifest_warnings.txt
+
+          python3 .scripts/validator/check-readme-metadata.py \
+            -d unpacked_plugin \
+            --error-file /tmp/readme_errors.txt \
+            --warning-file /tmp/readme_warnings.txt
+
+          python3 .scripts/validator/check-package-dependencies.py \
+            -d unpacked_plugin \
+            --error-file /tmp/package_dependencies_errors.txt \
+            --warning-file /tmp/package_dependencies_warnings.txt
+
+          python3 .scripts/validator/check-prohibited-financial-activity.py \
+            -d unpacked_plugin \
+            --warning-file /tmp/prohibited_financial_activity_warnings.txt
+
       - name: Upload Plugin
         run: |
           python3 .scripts/uploader/upload-package.py -p ${{ env.PLUGIN_PATH }} -t ${{ secrets.MARKETPLACE_TOKEN }} --plugin-daemon-path .scripts/dify-plugin-linux-amd64 -u ${{ secrets.MARKETPLACE_BASE_URL }}


### PR DESCRIPTION
Expands the PR pre-check with the marketplace toolkit's validators and switches the uploader to its package invocation.

```mermaid
flowchart LR
    PR["Plugin PR"] --> PC["pre-check:<br/>a dozen toolkit validators<br/>+ install test + packaging check"]
    PC --> S["one validation summary,<br/>fail at the end"]
    MG["merge to main"] --> UM["upload-merged:<br/>revalidate package"]
    UM --> UP["python3 .scripts/uploader"]
    UP --> M1["POST /plugins/inner-upload"]
    UP --> M2["PUT /plugin-artifacts/{checksum}/scan-report"]
```

- Every check is a `validator/check-*.py` CLI from [dify-marketplace-toolkit](https://github.com/langgenius/dify-marketplace-toolkit). Blocking findings and review warnings are collected into a single summary instead of dying on the first error.
- The merged package is revalidated before upload.
- `pre-check-plugin-sandbox.yaml` is a copy of the pre-check triggered only by PRs targeting a `precheck-sandbox` branch, so check changes can be exercised without touching real submissions.
- The uploader is invoked as a package: `python3 .scripts/uploader`. It uploads and then submits the security scan report against the returned artifact checksum on its own — workflows carry no scan logic, and a report failure warns without failing a publish.

Merge after langgenius/dify-marketplace-toolkit#4, which ships the package entry point (the old `upload-package.py` path keeps working there as an alias until both plugin repositories migrate).