### PR TITLE
fix(ci): the staging failure report must not fail the job

### DIFF
--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -143,17 +143,21 @@ jobs:
 
       - name: Report a failed staging upload
         if: steps.upload-staging.outcome == 'failure'
+        # Reporting must not do what it reports about. A 403 from the comment
+        # API or a rate limit would otherwise redden a production publish that
+        # succeeded, which is exactly the re-run this step exists to avoid. The
+        # job summary needs no token, so it is written first and unconditionally.
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PLUGIN: ${{ env.PLUGIN_PATH }}
         run: |
-          gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/comments" \
-            -f body="$(printf '%s\n' \
-              "**Staging upload failed** for \`$PLUGIN\`." \
-              "" \
-              "The plugin **is** published to production -- only <https://marketplace-staging.dify.dev> is missing it, so nothing needs re-merging or re-reviewing." \
-              "" \
-              "Reason: [workflow run]($RUN_URL). The next push of this plugin, or a backfill run, will bring staging back in line." \
-              "" \
-              "_This comment exists because the staging leg is deliberately non-blocking._")"
+          report=$(printf '%s\n' \
+            "**Staging upload failed** for \`$PLUGIN\`." \
+            "" \
+            "The plugin **is** published to production -- only <https://marketplace-staging.dify.dev> is missing it, so nothing needs re-merging or re-reviewing." \
+            "" \
+            "Reason: [workflow run]($RUN_URL). The next push of this plugin, or a backfill run, will bring staging back in line.")
+          printf '%s\n' "$report" >> "$GITHUB_STEP_SUMMARY"
+          gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/comments" -f body="$report"

--- a/.github/workflows/upload-merged-plugin.yaml
+++ b/.github/workflows/upload-merged-plugin.yaml
@@ -123,10 +123,9 @@ jobs:
         run: |
           python3 .scripts/uploader -p ${{ env.PLUGIN_PATH }} -t ${{ secrets.MARKETPLACE_TOKEN }} --plugin-daemon-path .scripts/dify-plugin-linux-amd64 -u ${{ secrets.MARKETPLACE_BASE_URL }}
 
-      # Staging cannot be tested without receiving uploads: the backend's
-      # latest/recommended rebuilds only run when an upload signals them.
-      # It must never block a release though -- a red merge workflow invites a
-      # re-run, which uploads the package again. -f keeps that re-run idempotent.
+      # Staging only becomes testable once uploads reach it: the backend rebuilds
+      # latest/recommended on an upload signal. Never blocking, though -- a red run
+      # invites a re-run, which re-uploads; -f keeps that idempotent.
       - name: Upload Plugin (staging)
         id: upload-staging
         continue-on-error: true
@@ -143,10 +142,8 @@ jobs:
 
       - name: Report a failed staging upload
         if: steps.upload-staging.outcome == 'failure'
-        # Reporting must not do what it reports about. A 403 from the comment
-        # API or a rate limit would otherwise redden a production publish that
-        # succeeded, which is exactly the re-run this step exists to avoid. The
-        # job summary needs no token, so it is written first and unconditionally.
+        # Summary needs no token; the comment is best-effort. Neither may redden
+        # a production publish that already succeeded.
         continue-on-error: true
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Follow-up to #2864, which merged one commit before this fix landed on the branch. Raised by Copilot on that PR.

## Problem

`continue-on-error` covers the staging upload but not the step that reports its failure. That step calls `gh api …/commits/{sha}/comments`, so a 403 on the comment API, a rate limit or a transient 5xx fails it and turns red a matrix job whose **production publish already succeeded**.

That is precisely the outcome the step exists to avoid: a red merge workflow invites a re-run, and here the production upload carries no `-f`, so the re-run 409s and fails again.

## Change

The report step is `continue-on-error` too, and no longer depends on the token to be useful: the message goes to `$GITHUB_STEP_SUMMARY` first, which needs no permissions, and the commit comment is best-effort after it.

Verified by running the step's script with a `gh` stub that exits 1 on a simulated 403 — the script exits 1, `continue-on-error` absorbs it, and the summary still carries the full report. `actionlint`: 4 → 4 findings, all pre-existing.
